### PR TITLE
Introducing AdviceLog Model

### DIFF
--- a/aira/migrations/0019_advicelog.py
+++ b/aira/migrations/0019_advicelog.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aira', '0018_agrifield_profile_additions'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='AdviceLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
+                ('inet', models.CharField(max_length=10)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('agrifield', models.ForeignKey(to='aira.Agrifield')),
+            ],
+        ),
+    ]

--- a/aira/models.py
+++ b/aira/models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 from collections import OrderedDict
 
 from django.db import models
@@ -302,6 +303,24 @@ class Agrifield(models.Model):
     @property
     def status(self):
         return cache.get('agrifield_{}_status'.format(self.id))
+
+
+class AdviceLog(models.Model):
+    agrifield = models.ForeignKey(Agrifield)
+    inet = models.CharField(max_length=10)
+    advice = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return "Agr:{}|Created:{}|Inet:{}".format(
+                    self.agrifield.id,
+                    self.created_at,
+                    self.inet
+                )
+
+    @property
+    def advice(self):
+        return json.dumps(self.advice)
 
 
 class IrrigationLog(models.Model):


### PR DESCRIPTION
Currently  aira runs SWB (soil water balance) on Agrifield save and in cronjob using a special management command.

There is nowhere a step of saving this information. Saving the Advice information against model run parameters . 

AdviceLog model is the main model that will hold this information after the replacement of celery with redis-rq and update of model run source code. This is why is needed as single separate commit and as a first step. 

For example model run should return a dict with all this information:
```
                {
                    "Agrifield": (str) Agrifield Name ex. Field 1,
                    "Parameters": (dict) Parameters used on this run
                    "Owner": (str) Agrifield Owner
                    "Inet": (str),
                    "forecast_sdd": (str) date format: "%Y-%m-%d %H:%M:%S",
                    "forecast_edd": (str) date format: "%Y-%m-%d %H:%M:%S",
                    "historical_sdd": (str) date format: "%Y-%m-%d %H:%M:%S",
                    "historical_edd": (str) date format: "%Y-%m-%d %H:%M:%S"),
                    "has_advice": True or  False,
                    "advice": [
                        {
                        'date': (str) date format: "%Y-%m-%d %H:%M:%S"),
                        'ifinal': (float),
                        'ifinal_m3': (float),
                        'ks': (float),
                        }
                    ]
                    "last_day": {
                        "ifinal": (float),
                        "ifinal_m3": (float)
                    }
```

In order to save this dict to databases that not support JSON in AdviceModel is used `advice = models.TextField()` ,  a **TextField** with getter, 

```
@property
def advice(self):
    return json.dumps(self.advice)
```

If aira requirements are updated to use only Postgres DB when the specific model field can be used 
https://docs.djangoproject.com/en/2.0/ref/contrib/postgres/fields/#jsonfield