### PR TITLE
Remove deprecated AlbedoMaps view (fixes#143)

### DIFF
--- a/aira/urls.py
+++ b/aira/urls.py
@@ -7,15 +7,13 @@ from aira.views import (IndexPageView, HomePageView, AdvicePageView,
                         CreateAgrifield, UpdateAgrifield, DeleteAgrifield,
                         CreateIrrigationLog, UpdateIrrigationLog,
                         DeleteIrrigationLog,
-                        TryPageView, AlbedoMapsPageView,
+                        TryPageView,
                         ConversionTools, IrrigationPerformance,
                         performance_csv, remove_supervised_user_from_user_list)
 
 urlpatterns = patterns(
     '',
     url(r'^$', IndexPageView.as_view(), name='welcome'),
-    # Albedo Maps
-    url(r'albedo_maps/$', AlbedoMapsPageView.as_view(), name='maps'),
     # Home
 
     url(r'^home/(?P<username>[\w.@+-]+)/$',

--- a/aira/views.py
+++ b/aira/views.py
@@ -89,10 +89,6 @@ class IndexPageView(TemplateView):
         return context
 
 
-class AlbedoMapsPageView(TemplateView):
-    template_name = 'aira/albedo_maps.html'
-
-
 class HomePageView(TemplateView):
     template_name = 'aira/home.html'
 


### PR DESCRIPTION
### Backlog history

Initially AlbedoMaps views existed and used from https://github.com/openmeteo/aira-irma skin.  Its was basically a view with a list of images (https://github.com/openmeteo/aira-irma/blob/master/aira/albedo_maps.html). 
This is not more the case and this PR removes from core aira. We keep in the skin repo aira-irma just for reference and potential future usage.



